### PR TITLE
rescale clipping prproperly

### DIFF
--- a/SGDHess.py
+++ b/SGDHess.py
@@ -119,10 +119,10 @@ class SGDHess(Optimizer):
                                     if self.clip is not None:
                                         if self.clip == 'coord':
                                             torch.clamp_(buf, -max_grad, max_grad)
-                                            max_grad.copy_(torch.maximum(torch.abs(d_p), max_grad))
+                                            max_grad.copy_(torch.maximum((1-dampening)/(1-momentum)*torch.abs(d_p), max_grad))
                                         if self.clip == 'norm':
                                             torch.nn.utils.clip_grad_norm_(g, max_grad)
-                                            max_grad.copy_(torch.maximum(torch.norm(d_p), max_grad))
+                                            max_grad.copy_(torch.maximum((1-dampening)/(1-momentum)*torch.norm(d_p), max_grad))
                                     #buf.add_(hvp[i]).mul_(momentum).add_(d_p, alpha=1 - dampening)
                                 if nesterov:
                                     d_p = d_p.add(buf, alpha=momentum)


### PR DESCRIPTION
Since momentum!=dampening in general, we should expect the momentum_buffer to actually grow to size approximately G(1-dampening)/(1-momentum), so it is not correct to clip it to norm only G.